### PR TITLE
Enable EZProxy pseudonymous identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ ssl/
 cookies/
 
 # Contains sensitive authentication configuration.
+secrets.txt
+secrets.txt.bak
 ezproxy.usr
 ezproxy.usr.bak
 .env

--- a/expert/ezproxy.cfg
+++ b/expert/ezproxy.cfg
@@ -14,6 +14,9 @@ Host https://ssl.geoplugin.net
 HJ https://ssl.geoplugin.net
 DJ geoplugin.net
 
+# ************************ PSUEDONYMOUS IDENTIFIER ************************************************
+IncludeFile secrets.txt
+
 # ************************ LIBRARY CARD BUNDLE ****************************************************
 
 Group BUNDLE


### PR DESCRIPTION
Adds a git-ignored secrets file to store Identifier secrets
Bug: [T376708](https://phabricator.wikimedia.org/T376708)